### PR TITLE
Draw arrowhead at the end of each line

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -14,7 +14,14 @@ pub const CHAR_VER_LEFT_L: char = '┤';
 pub const CHAR_ARROW_DOWN: char = '🭯';
 pub const CHAR_ARROW_UP: char = '🭭';
 pub const CHAR_ARROW_RIGHT: char = '►';
-pub const CHAR_ARROW_LEFT: char = '◄'; // '◂';
+pub const CHAR_ARROW_LEFT: char = '◄';
+
+pub fn is_arrowhead(c: char) -> bool {
+    c.eq(&CHAR_ARROW_LEFT)
+        || c.eq(&CHAR_ARROW_RIGHT)
+        || c.eq(&CHAR_ARROW_UP)
+        || c.eq(&CHAR_ARROW_DOWN)
+}
 
 pub const CHAR_SPACE: char = ' ';
 pub const CHAR_NEWLINE: char = '\n';

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -11,6 +11,11 @@ pub const CHAR_HOR_DOWN_L: char = '┬';
 pub const CHAR_VER_RIGHT_L: char = '├';
 pub const CHAR_VER_LEFT_L: char = '┤';
 
+pub const CHAR_ARROW_DOWN: char = '🭯';
+pub const CHAR_ARROW_UP: char = '🭭';
+pub const CHAR_ARROW_RIGHT: char = '►';
+pub const CHAR_ARROW_LEFT: char = '◄'; // '◂';
+
 pub const CHAR_SPACE: char = ' ';
 pub const CHAR_NEWLINE: char = '\n';
 

--- a/src/shapes/line.rs
+++ b/src/shapes/line.rs
@@ -2,8 +2,9 @@ use druid::Point;
 
 use crate::{
     consts::{
-        CHAR_CORNER_BL_L, CHAR_CORNER_BR_L, CHAR_CORNER_TL_L, CHAR_CORNER_TR_L, CHAR_HOR_DOWN_L,
-        CHAR_HOR_L, CHAR_HOR_UP_L, CHAR_SPACE, CHAR_VER_L, CHAR_VER_LEFT_L, CHAR_VER_RIGHT_L,
+        CHAR_ARROW_DOWN, CHAR_ARROW_LEFT, CHAR_ARROW_RIGHT, CHAR_ARROW_UP, CHAR_CORNER_BL_L,
+        CHAR_CORNER_BR_L, CHAR_CORNER_TL_L, CHAR_CORNER_TR_L, CHAR_HOR_DOWN_L, CHAR_HOR_L,
+        CHAR_HOR_UP_L, CHAR_SPACE, CHAR_VER_L, CHAR_VER_LEFT_L, CHAR_VER_RIGHT_L,
     },
     data::grid_list::GridList,
 };
@@ -42,6 +43,14 @@ impl ShapeRender for LineShape {
                 for row in from..=to {
                     let i = row * cols + from_col;
                     grid_buffer.get(i).set_preview(CHAR_VER_L);
+                }
+
+                if from_row > to_row {
+                    let head_i = from * cols + from_col;
+                    grid_buffer.get(head_i).set_preview(CHAR_ARROW_DOWN);
+                } else {
+                    let head_i = to * cols + from_col;
+                    grid_buffer.get(head_i).set_preview(CHAR_ARROW_UP);
                 }
 
                 if grid_buffer.get(start_i).read_content() == CHAR_HOR_L {
@@ -83,6 +92,14 @@ impl ShapeRender for LineShape {
                 for col in from..=to {
                     let i = from_row * cols + col;
                     grid_buffer.get(i).set_preview(CHAR_HOR_L);
+                }
+
+                if from_col > to_col {
+                    let head_i = from_row * cols + from;
+                    grid_buffer.get(head_i).set_preview(CHAR_ARROW_LEFT);
+                } else {
+                    let head_i = from_row * cols + to;
+                    grid_buffer.get(head_i).set_preview(CHAR_ARROW_RIGHT);
                 }
 
                 if grid_buffer.get(start_i).read_content() == CHAR_VER_L {

--- a/src/shapes/line.rs
+++ b/src/shapes/line.rs
@@ -2,9 +2,9 @@ use druid::Point;
 
 use crate::{
     consts::{
-        CHAR_ARROW_DOWN, CHAR_ARROW_LEFT, CHAR_ARROW_RIGHT, CHAR_ARROW_UP, CHAR_CORNER_BL_L,
-        CHAR_CORNER_BR_L, CHAR_CORNER_TL_L, CHAR_CORNER_TR_L, CHAR_HOR_DOWN_L, CHAR_HOR_L,
-        CHAR_HOR_UP_L, CHAR_SPACE, CHAR_VER_L, CHAR_VER_LEFT_L, CHAR_VER_RIGHT_L,
+        is_arrowhead, CHAR_ARROW_DOWN, CHAR_ARROW_LEFT, CHAR_ARROW_RIGHT, CHAR_ARROW_UP,
+        CHAR_CORNER_BL_L, CHAR_CORNER_BR_L, CHAR_CORNER_TL_L, CHAR_CORNER_TR_L, CHAR_HOR_DOWN_L,
+        CHAR_HOR_L, CHAR_HOR_UP_L, CHAR_SPACE, CHAR_VER_L, CHAR_VER_LEFT_L, CHAR_VER_RIGHT_L,
     },
     data::grid_list::GridList,
 };
@@ -34,6 +34,7 @@ impl ShapeRender for LineShape {
         grid_buffer.discard_all();
 
         let start_i = from_row * cols + from_col;
+        let start_char = grid_buffer.get(start_i).read_content().to_owned();
 
         match self.direction {
             LineDirection::Vertical => {
@@ -53,7 +54,7 @@ impl ShapeRender for LineShape {
                     grid_buffer.get(head_i).set_preview(CHAR_ARROW_UP);
                 }
 
-                if grid_buffer.get(start_i).read_content() == CHAR_HOR_L {
+                if start_char == CHAR_HOR_L || is_arrowhead(start_char) {
                     let prev_i = from_row * cols + (from_col - 1);
                     let next_i = from_row * cols + (from_col + 1);
                     if grid_buffer.get(prev_i).read() == CHAR_SPACE {
@@ -102,7 +103,7 @@ impl ShapeRender for LineShape {
                     grid_buffer.get(head_i).set_preview(CHAR_ARROW_RIGHT);
                 }
 
-                if grid_buffer.get(start_i).read_content() == CHAR_VER_L {
+                if start_char == CHAR_VER_L || is_arrowhead(start_char) {
                     let prev_i = (from_row - 1) * cols + from_col;
                     let next_i = (from_row + 1) * cols + from_col;
                     if grid_buffer.get(prev_i).read() == CHAR_SPACE {

--- a/src/widgets/grid.rs
+++ b/src/widgets/grid.rs
@@ -8,8 +8,7 @@ use druid::{
 use crate::{
     consts::{CANVAS_SIZE, SELECTION_END_COMMAND, SELECTION_MOVE_COMMAND, SELECTION_START_COMMAND},
     data::{
-        grid_cell::GridCell, grid_list::GridList, selection::SelectionRange, shape_list::ShapeList,
-        ApplicationState,
+        grid_list::GridList, selection::SelectionRange, shape_list::ShapeList, ApplicationState,
     },
     tools::{DrawingTools, ToolControl, ToolManager},
 };
@@ -61,15 +60,6 @@ impl CanvasGrid {
             let rows = (self.height / cell_height) as usize;
             let cols = (self.width / cell_width) as usize;
             self.grid_list = GridList::new(cell_width, cell_height, rows, cols);
-            for row in 0..rows {
-                for col in 0..cols {
-                    let i = row * cols + col;
-                    if i >= cols && i % cols == 0 {
-                        let cell = self.grid_list.get(i as usize);
-                        *cell = GridCell::newline();
-                    }
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
This PR added arrowhead to the end of each line in the Line tool.

The output will look like this:

```
                                       
                                       
                                       
   ┌─────────┐       ┌────────────────┐
   │ server  ├─────► │   wolololo()   │
   └─────────┘       └──┬─────────────┘
                        │              
                        └────►         
                                       
```