### PR TITLE
Better file handling and keyboard shortcuts

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -10,4 +10,5 @@ pub mod shape_list;
 #[derive(Clone, PartialEq, Data)]
 pub struct ApplicationState {
     pub mode: DrawingTools,
+    pub current_file: Option<String>,
 }


### PR DESCRIPTION
Some changes in this PR:

![image](https://user-images.githubusercontent.com/613943/220793686-a9e01441-4345-4609-a2ef-b5b1788825f2.png)

### Handle opened file
Now handle the current opened file, after the first time you open or save a file, ASCII-d will "remember" this file as the current file. On the next save, it will save to the current file, no save dialog will be opened.

### Support multiple windows
You can open a new window using the <kbd>Meta</kbd><kbd>N</kbd> shortcut.

### More keyboard shortcuts
Some new keyboard shortcuts added:

- <kbd>Meta</kbd><kbd>O</kbd>: Open a new file
- <kbd>Meta</kbd><kbd>S</kbd>: Save the current buffer to file
- <kbd>Meta</kbd><kbd>C</kbd>: Copy current buffer content into the Clipboard
- <kbd>Meta</kbd><kbd>N</kbd>: Open a new empty window