### PR TITLE
feat: Implement copy/paste selection feature

### DIFF
--- a/src/data/grid_cell.rs
+++ b/src/data/grid_cell.rs
@@ -2,6 +2,7 @@ use crate::consts::{CHAR_NEWLINE, CHAR_SPACE};
 
 #[derive(Clone, Copy)]
 pub struct GridCell {
+    pub highlight_index: usize,
     pub content: char,
     pub preview: Option<char>,
     pub highlighted: bool,
@@ -10,6 +11,7 @@ pub struct GridCell {
 impl GridCell {
     pub fn new(content: char) -> Self {
         Self {
+            highlight_index: 0,
             content,
             preview: None,
             highlighted: false,
@@ -38,6 +40,7 @@ impl GridCell {
     pub fn clear(&mut self) {
         self.content = CHAR_SPACE;
         self.preview = None;
+        self.highlight_index = 0;
     }
 
     pub fn set_content(&mut self, content: char) {
@@ -59,11 +62,13 @@ impl GridCell {
         self.preview = None;
     }
 
-    pub fn highlight(&mut self) {
+    pub fn highlight(&mut self, highlight_index: usize) {
         self.highlighted = true;
+        self.highlight_index = highlight_index;
     }
 
     pub fn clear_highlight(&mut self) {
         self.highlighted = false;
+        self.highlight_index = 0;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
+use consts::SELECTION_END_COMMAND;
 use druid::{
     commands::NEW_FILE,
     widget::{Scroll, SizedBox},
     AppDelegate, AppLauncher, Application, Code, Command, DelegateCtx, Env, Event, Handled,
-    LifeCycle, PlatformError, Target, Widget, WidgetPod, WindowDesc, WindowId,
+    LifeCycle, PlatformError, Point, Target, Widget, WidgetPod, WindowDesc, WindowId,
 };
 
 #[macro_use]
@@ -51,6 +52,11 @@ impl Widget<ApplicationState> for MainWindow {
             ui.add_child(Scroll::new(CanvasGrid::new(ctx)));
             ui.add_child(ToolBarWidget::new());
             self.content = WidgetPod::new(Box::new(ui));
+        }
+        if let LifeCycle::HotChanged(is_hot) = event {
+            if !is_hot {
+                ctx.submit_command(SELECTION_END_COMMAND.with(Point { x: 0.0, y: 0.0 }));
+            }
         }
         self.content.lifecycle(ctx, event, data, env);
     }
@@ -133,7 +139,11 @@ impl AppDelegate<ApplicationState> for Delegate {
 fn main() -> Result<(), PlatformError> {
     // https://github.com/linebender/druid/pull/1701/files
     // Follow the above PR for transparent title bar status
-    let app = AppLauncher::with_window(WindowDesc::new(MainWindow::new()).title("ASCII-d"));
+    let app = AppLauncher::with_window(
+        WindowDesc::new(MainWindow::new())
+            .title("ASCII-d")
+            .window_size((640.0, 480.0)),
+    );
     app.delegate(Delegate {
         windows: Vec::new(),
     })

--- a/src/widgets/image_button.rs
+++ b/src/widgets/image_button.rs
@@ -42,6 +42,7 @@ impl<T: Data> Widget<T> for ImageButton<T> {
                 if !ctx.is_disabled() {
                     ctx.set_active(true);
                     ctx.request_paint();
+                    ctx.set_handled();
                 }
             }
             Event::MouseUp(_) => {

--- a/src/widgets/toolbar.rs
+++ b/src/widgets/toolbar.rs
@@ -177,27 +177,6 @@ impl Widget<ApplicationState> for ToolBarWidget {
             Event::WindowConnected => {
                 ctx.submit_command(BUTTON_HIGHLIGHT_COMMAND.with(data.mode.to_string()));
             }
-            Event::MouseDown(event) | Event::MouseUp(event) | Event::MouseMove(event) => {
-                let Self {
-                    left_buttons,
-                    right_buttons,
-                } = &self;
-
-                for area in &[left_buttons, right_buttons] {
-                    let position = area.layout_rect().origin();
-                    let content_width = area.layout_rect().width(); //.min(ctx.window().get_size().width - 2.0 * 26.0);
-                    let size = ctx.size();
-                    let rect = Rect::new(
-                        position.x - 4.0,
-                        size.height - 53.0,
-                        position.x - 4.0 + content_width + 12.0,
-                        size.height - 17.0,
-                    );
-                    if rect.contains(event.pos) {
-                        ctx.set_handled();
-                    }
-                }
-            }
             Event::Notification(notification) => {
                 if let Some(name) = notification.get(BUTTON_HIGHLIGHT_COMMAND) {
                     ctx.submit_command(BUTTON_HIGHLIGHT_COMMAND.with(name.to_string()));


### PR DESCRIPTION
Add an ability to select, cut/copy and paste.

- In cursor mode, click and drag on the grid to select content
- Use <kbd>Meta</kbd><kbd>C</kbd> to copy the selected content
- Use <kbd>Meta</kbd><kbd>X</kbd> to cut the selected content
- Use <kbd>Meta</kbd><kbd>V</kbd> to paste the clipboard content into the mouse position

![ascii-d-copy-paste](https://user-images.githubusercontent.com/613943/221081911-a085bcc7-8374-4deb-bca9-0950c53f055e.gif)

