### PR TITLE
feat: Undo and Redo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ name = "ascii-d"
 version = "0.2.0"
 dependencies = [
  "druid",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 druid = { git = "https://github.com/linebender/druid", version = "0.8.2", features = ["image", "png"] }
+once_cell = "1.17.1"
 
 [package.metadata.bundle]
 copyright = "Copyright (c) Huy Tran 2023. All rights reserved."

--- a/src/data/grid_list.rs
+++ b/src/data/grid_list.rs
@@ -1,4 +1,7 @@
-use super::grid_cell::GridCell;
+use super::{
+    grid_cell::GridCell,
+    history::{Version, HISTORY_MANAGER},
+};
 use druid::Rect;
 use std::fmt::Display;
 
@@ -59,6 +62,10 @@ impl GridList {
         &mut self.data[index]
     }
 
+    pub fn set(&mut self, index: usize, content: char) {
+        self.data[index].content = content;
+    }
+
     pub fn get_highlighted_content(&mut self) -> String {
         let mut last_i: Option<usize> = None;
         let cells = self.data.iter_mut().filter(|cell| cell.highlighted);
@@ -113,12 +120,18 @@ impl GridList {
     }
 
     pub fn erase_highlighted(&mut self) {
+        let mut version = Version::new();
         self.data
             .iter_mut()
-            .filter(|cell| cell.highlighted)
-            .for_each(|cell| {
+            .enumerate()
+            .filter(|(_, cell)| cell.highlighted)
+            .for_each(|(i, cell)| {
+                version.push(i, cell.content, ' ');
                 cell.clear();
             });
+        unsafe {
+            HISTORY_MANAGER.save_version(version);
+        }
     }
 
     pub fn clear_all_highlight(&mut self) {
@@ -130,10 +143,16 @@ impl GridList {
     }
 
     pub fn commit_all(&mut self) {
-        for cell in self.data.iter_mut() {
+        let mut version = Version::new();
+        for (i, cell) in self.data.iter_mut().enumerate() {
             if cell.preview.is_some() {
+                let from = cell.content;
                 cell.commit();
+                version.push(i, from, cell.content);
             }
+        }
+        unsafe {
+            HISTORY_MANAGER.save_version(version);
         }
     }
 
@@ -146,6 +165,7 @@ impl GridList {
     }
 
     pub fn load_content_at(&mut self, content: String, row: usize, col: usize) {
+        let mut version = Version::new();
         let (_, cols) = self.grid_size;
         let mut row = row;
         for line in content.lines() {
@@ -153,11 +173,15 @@ impl GridList {
             for c in line.chars() {
                 if !c.is_whitespace() {
                     let i = row * cols + col;
+                    version.push(i, self.data[i].content, c);
                     self.data[i].set_content(c);
                 }
                 col += 1;
             }
             row += 1;
+        }
+        unsafe {
+            HISTORY_MANAGER.save_version(version);
         }
     }
 

--- a/src/data/history.rs
+++ b/src/data/history.rs
@@ -1,0 +1,84 @@
+use super::grid_list::GridList;
+use once_cell::sync::Lazy;
+
+#[derive(Debug, Clone)]
+struct Edit {
+    index: usize,
+    from: char,
+    to: char,
+}
+
+impl Edit {
+    pub fn new(index: usize, from: char, to: char) -> Self {
+        Self { index, from, to }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Version {
+    edits: Vec<Edit>,
+}
+
+impl Version {
+    pub fn new() -> Self {
+        Self { edits: vec![] }
+    }
+
+    pub fn push(&mut self, index: usize, from: char, to: char) {
+        self.edits.push(Edit::new(index, from, to));
+    }
+
+    pub fn len(&self) -> usize {
+        self.edits.len()
+    }
+}
+
+pub struct History {
+    versions: Vec<Version>,
+    index: usize,
+}
+
+impl History {
+    pub fn new() -> Self {
+        Self {
+            versions: vec![],
+            index: 0,
+        }
+    }
+
+    pub fn save_version(&mut self, version: Version) {
+        if version.len() > 0 {
+            if self.index + 1 >= self.versions.len() {
+                // Push new history
+                self.versions.push(version);
+            } else {
+                // Overwriting history
+                self.versions = self.versions[0..self.index].to_vec();
+                self.versions.push(version);
+            }
+            self.index = self.versions.len();
+        }
+    }
+
+    pub fn undo(&mut self, grid_list: &mut GridList) {
+        if self.index > 0 {
+            self.index -= 1;
+            let version = &self.versions[self.index];
+            for edit in &version.edits {
+                grid_list.set(edit.index, edit.from);
+            }
+        }
+    }
+
+    pub fn redo(&mut self, grid_list: &mut GridList) {
+        if self.index < self.versions.len() {
+            let version = &self.versions[self.index];
+            for edit in &version.edits {
+                grid_list.set(edit.index, edit.to);
+            }
+            self.index += 1;
+        }
+    }
+}
+
+pub static mut HISTORY_MANAGER: Lazy<History> = Lazy::new(|| History::new());

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -4,6 +4,7 @@ use crate::tools::DrawingTools;
 
 pub mod grid_cell;
 pub mod grid_list;
+pub mod history;
 pub mod selection;
 pub mod shape_list;
 

--- a/src/tools/eraser.rs
+++ b/src/tools/eraser.rs
@@ -1,14 +1,22 @@
 use druid::EventCtx;
 
-use crate::data::{grid_list::GridList, shape_list::ShapeList};
+use crate::data::{
+    grid_list::GridList,
+    history::{Version, HISTORY_MANAGER},
+    shape_list::ShapeList,
+};
 
 use super::ToolControl;
 
-pub struct EraserTool;
+pub struct EraserTool {
+    version: Version,
+}
 
 impl EraserTool {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            version: Version::new(),
+        }
     }
 }
 
@@ -34,7 +42,9 @@ impl ToolControl for EraserTool {
         let col = (event.pos.x / cell_width) as usize;
         let (_rows, cols) = grid_list.grid_size;
         let i = row * cols + col;
-        grid_list.get(i).clear();
+        let cell = grid_list.get(i);
+        self.version.push(i, cell.content, ' ');
+        cell.clear();
     }
 
     fn input(
@@ -53,5 +63,8 @@ impl ToolControl for EraserTool {
         _shape_list: &mut ShapeList,
         _grid_list: &mut GridList,
     ) {
+        unsafe {
+            HISTORY_MANAGER.save_version(self.version.clone());
+        }
     }
 }

--- a/src/widgets/grid.rs
+++ b/src/widgets/grid.rs
@@ -10,7 +10,8 @@ use druid::{
 use crate::{
     consts::{CANVAS_SIZE, SELECTION_END_COMMAND, SELECTION_MOVE_COMMAND, SELECTION_START_COMMAND},
     data::{
-        grid_list::GridList, selection::SelectionRange, shape_list::ShapeList, ApplicationState,
+        grid_list::GridList, history::HISTORY_MANAGER, selection::SelectionRange,
+        shape_list::ShapeList, ApplicationState,
     },
     tools::{DrawingTools, ToolControl, ToolManager},
 };
@@ -136,6 +137,15 @@ impl Widget<ApplicationState> for CanvasGrid {
                                     Code::KeyN => {
                                         ctx.submit_command(NEW_FILE);
                                     }
+                                    Code::KeyZ => unsafe {
+                                        if event.mods.shift() {
+                                            // Redo
+                                            HISTORY_MANAGER.redo(&mut self.grid_list);
+                                        } else {
+                                            // Undo
+                                            HISTORY_MANAGER.undo(&mut self.grid_list);
+                                        }
+                                    },
                                     _ => {}
                                 }
                             }


### PR DESCRIPTION
Implemented the Undo and Redo feature.

Usage:

- <kbd>⌘</kbd><kbd>Z</kbd>: Undo 
- <kbd>⌘</kbd><kbd>⇧</kbd><kbd>Z</kbd>: Redo

https://user-images.githubusercontent.com/613943/226196309-96682237-be3b-4ea0-afc5-3e13e1d79930.mov

Due to the way we handled Text editing tool, every keystroke will be recorded as an Undo step, so, if you type "Hello", there will be 5 undo steps.

For other tools (Rect, Line, Erase, Copy/Paste,...), undo step will be recorded as a whole edit.

Currently, there's no limitation on how much undo steps to be recorded (unlimited history!), it gonna crash when the computer run out of memory, but let's wait and see.

