### PR TITLE
fix: undo operation of eraser tool

### DIFF
--- a/src/data/history.rs
+++ b/src/data/history.rs
@@ -39,7 +39,6 @@ impl Version {
 
 pub struct History {
     versions: Vec<Version>,
-    // redo_stack: Vec<Version>,
     index: usize,
 }
 
@@ -47,7 +46,6 @@ impl History {
     pub fn new() -> Self {
         Self {
             versions: vec![],
-            // redo_stack: vec![],
             index: 0,
         }
     }
@@ -64,11 +62,6 @@ impl History {
             }
             self.index = self.versions.len();
         }
-        // println!("{:?}\n", version);
-        // self.versions.push(version);
-        // if !self.redo_stack.is_empty() {
-        //     self.redo_stack.clear();
-        // }
     }
 
     pub fn undo(&mut self, grid_list: &mut GridList) {
@@ -79,13 +72,6 @@ impl History {
                 grid_list.set(edit.index, edit.from);
             }
         }
-        // if let Some(top) = self.versions.pop() {
-        //     println!("{:?}\n", top);
-        //     for edit in &top.edits {
-        //         grid_list.set(edit.index, edit.from);
-        //     }
-        //     self.redo_stack.push(top);
-        // }
     }
 
     pub fn redo(&mut self, grid_list: &mut GridList) {
@@ -96,13 +82,6 @@ impl History {
             }
             self.index += 1;
         }
-        // if let Some(top) = self.redo_stack.pop() {
-        //     println!("{:?}\n", top);
-        //     for edit in &top.edits {
-        //         grid_list.set(edit.index, edit.to);
-        //     }
-        //     self.versions.push(top);
-        // }
     }
 }
 

--- a/src/data/history.rs
+++ b/src/data/history.rs
@@ -28,6 +28,10 @@ impl Version {
         self.edits.push(Edit::new(index, from, to));
     }
 
+    pub fn clear(&mut self) {
+        self.edits.clear();
+    }
+
     pub fn len(&self) -> usize {
         self.edits.len()
     }
@@ -35,6 +39,7 @@ impl Version {
 
 pub struct History {
     versions: Vec<Version>,
+    // redo_stack: Vec<Version>,
     index: usize,
 }
 
@@ -42,6 +47,7 @@ impl History {
     pub fn new() -> Self {
         Self {
             versions: vec![],
+            // redo_stack: vec![],
             index: 0,
         }
     }
@@ -58,6 +64,11 @@ impl History {
             }
             self.index = self.versions.len();
         }
+        // println!("{:?}\n", version);
+        // self.versions.push(version);
+        // if !self.redo_stack.is_empty() {
+        //     self.redo_stack.clear();
+        // }
     }
 
     pub fn undo(&mut self, grid_list: &mut GridList) {
@@ -68,6 +79,13 @@ impl History {
                 grid_list.set(edit.index, edit.from);
             }
         }
+        // if let Some(top) = self.versions.pop() {
+        //     println!("{:?}\n", top);
+        //     for edit in &top.edits {
+        //         grid_list.set(edit.index, edit.from);
+        //     }
+        //     self.redo_stack.push(top);
+        // }
     }
 
     pub fn redo(&mut self, grid_list: &mut GridList) {
@@ -78,7 +96,14 @@ impl History {
             }
             self.index += 1;
         }
+        // if let Some(top) = self.redo_stack.pop() {
+        //     println!("{:?}\n", top);
+        //     for edit in &top.edits {
+        //         grid_list.set(edit.index, edit.to);
+        //     }
+        //     self.versions.push(top);
+        // }
     }
 }
 
-pub static mut HISTORY_MANAGER: Lazy<History> = Lazy::new(|| History::new());
+pub static mut HISTORY_MANAGER: Lazy<History> = Lazy::new(History::new);

--- a/src/tools/eraser.rs
+++ b/src/tools/eraser.rs
@@ -33,6 +33,7 @@ impl ToolControl for EraserTool {
         _shape_list: &mut ShapeList,
         _grid_list: &mut GridList,
     ) {
+        self.last_cursor_position = None;
     }
 
     fn draw(


### PR DESCRIPTION
The eraser tool does not work well in #20. This pr is to fix it.

As [the comment](https://github.com/huytd/ascii-d/pull/20#issuecomment-1475611933) says, if I follow the steps, there will be some weird chars on the canvas, since the version vector is not cleared. Then it is fixed with these changes: [history.rs](https://github.com/huytd/ascii-d/compare/master...widcardw:ascii-d:fix-eraser-undo?expand=1#diff-e755b60e7cd2b34195c4dbecc3e587bdf5d0d7d99c790e4337513bea6d5113bdR31-R34) and [eraser.rs](https://github.com/huytd/ascii-d/compare/master...widcardw:ascii-d:fix-eraser-undo?expand=1#diff-97a2b05217e4c4de9232ce3c83601efd538a5b71461f1a55b1900691e8bd6b7fR80).