### PR TITLE
feat: Moving selection

### DIFF
--- a/src/data/grid_list.rs
+++ b/src/data/grid_list.rs
@@ -9,6 +9,7 @@ pub struct GridList {
     data: Vec<GridCell>,
     pub cell_size: (f64, f64),
     pub grid_size: (usize, usize),
+    pub current_selection: Option<((usize, usize), (usize, usize))>,
 }
 
 impl Display for GridList {
@@ -42,6 +43,7 @@ impl GridList {
             data: vec![],
             cell_size: (0.0, 0.0),
             grid_size: (0, 0),
+            current_selection: None,
         }
     }
 
@@ -50,6 +52,7 @@ impl GridList {
             data: vec![GridCell::empty(); rows * cols],
             cell_size: (cell_width, cell_height),
             grid_size: (rows, cols),
+            current_selection: None,
         }
     }
 
@@ -117,6 +120,8 @@ impl GridList {
                 self.data[index].highlight(index);
             }
         }
+
+        self.current_selection = Some(((start_row, start_col), (end_row, end_col)));
     }
 
     pub fn erase_highlighted(&mut self) {
@@ -140,6 +145,7 @@ impl GridList {
                 cell.clear_highlight();
             }
         }
+        self.current_selection = None;
     }
 
     pub fn commit_all(&mut self) {
@@ -161,6 +167,22 @@ impl GridList {
             if cell.preview.is_some() {
                 cell.discard();
             }
+        }
+    }
+
+    pub fn put_preview_at(&mut self, content: &str, row: usize, col: usize) {
+        let (_, cols) = self.grid_size;
+        let mut row = row;
+        for line in content.lines() {
+            let mut col = col;
+            for c in line.chars() {
+                if !c.is_whitespace() {
+                    let i = row * cols + col;
+                    self.data[i].set_preview(c);
+                }
+                col += 1;
+            }
+            row += 1;
         }
     }
 

--- a/src/shapes/block.rs
+++ b/src/shapes/block.rs
@@ -1,0 +1,52 @@
+use druid::Point;
+
+use crate::{
+    consts::{
+        CHAR_CORNER_BL_L, CHAR_CORNER_BR_L, CHAR_CORNER_TL_L, CHAR_CORNER_TR_L, CHAR_HOR_L,
+        CHAR_VER_L,
+    },
+    data::grid_list::GridList,
+};
+
+use super::ShapeRender;
+
+pub struct BlockShape {
+    pub start: (usize, usize),
+    pub end: (usize, usize),
+    pub preview: bool,
+    pub content: String,
+}
+
+impl BlockShape {
+    pub fn new(row: usize, col: usize, content: String) -> Self {
+        Self {
+            start: (row, col),
+            end: (row, col),
+            preview: true,
+            content: content,
+        }
+    }
+}
+
+impl_shape_for!(BlockShape);
+
+impl ShapeRender for BlockShape {
+    fn draw(&mut self, grid_buffer: &mut GridList) {
+        let (row, col) = self.start;
+        grid_buffer.discard_all();
+        grid_buffer.put_preview_at(&self.content, row, col)
+    }
+
+    fn commit(&mut self, grid_buffer: &mut GridList) {
+        grid_buffer.commit_all();
+        self.preview = false;
+    }
+
+    fn is_preview(&self) -> bool {
+        self.preview
+    }
+
+    fn is_manual_commit(&self) -> bool {
+        false
+    }
+}

--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -4,6 +4,7 @@ use druid::Point;
 
 use crate::data::grid_list::GridList;
 
+pub mod block;
 pub mod line;
 pub mod rect;
 

--- a/src/tools/select.rs
+++ b/src/tools/select.rs
@@ -1,5 +1,7 @@
 use druid::EventCtx;
+use std::ops::Sub;
 
+use crate::shapes::block::BlockShape;
 use crate::{
     consts::{SELECTION_END_COMMAND, SELECTION_MOVE_COMMAND, SELECTION_START_COMMAND},
     data::{grid_list::GridList, shape_list::ShapeList},
@@ -7,11 +9,19 @@ use crate::{
 
 use super::ToolControl;
 
-pub struct SelectTool;
+pub struct SelectTool {
+    is_selecting: bool,
+    offset_row: usize,
+    offset_col: usize,
+}
 
 impl SelectTool {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            is_selecting: false,
+            offset_row: 0,
+            offset_col: 0,
+        }
     }
 }
 
@@ -20,20 +30,52 @@ impl ToolControl for SelectTool {
         &mut self,
         ctx: &mut EventCtx,
         event: &druid::MouseEvent,
-        _shape_list: &mut ShapeList,
-        _grid_list: &mut GridList,
+        shape_list: &mut ShapeList,
+        grid_list: &mut GridList,
     ) {
-        ctx.submit_command(SELECTION_START_COMMAND.with(event.pos));
+        let (cell_width, cell_height) = grid_list.cell_size;
+        let (_, cols) = grid_list.grid_size;
+        let row = (event.pos.y / cell_height) as usize;
+        let col = (event.pos.x / cell_width) as usize;
+        let i = row * cols + col;
+        if !grid_list.get(i).highlighted {
+            ctx.submit_command(SELECTION_START_COMMAND.with(event.pos));
+            self.is_selecting = true;
+        } else {
+            if let Some(((sel_row, sel_col), _)) = grid_list.current_selection {
+                // Calculate the offset between current mouse pos and selection rect
+                self.offset_row = (row as isize - sel_row as isize).abs() as usize;
+                self.offset_col = (col as isize - sel_col as isize).abs() as usize;
+                // Create new block shape here
+                let block_content = grid_list.get_highlighted_content();
+                grid_list.erase_highlighted();
+                grid_list.clear_all_highlight();
+                shape_list.add_shape(Box::new(BlockShape::new(row, col, block_content)));
+            }
+        }
     }
 
     fn draw(
         &mut self,
         ctx: &mut EventCtx,
         event: &druid::MouseEvent,
-        _shape_list: &mut ShapeList,
-        _grid_list: &mut GridList,
+        shape_list: &mut ShapeList,
+        grid_list: &mut GridList,
     ) {
-        ctx.submit_command(SELECTION_MOVE_COMMAND.with(event.pos));
+        if self.is_selecting {
+            ctx.submit_command(SELECTION_MOVE_COMMAND.with(event.pos));
+        } else {
+            if let Some(block) = shape_list.data.last_mut() {
+                if let Some(mut block) = block.as_any_mut().downcast_mut::<BlockShape>() {
+                    let (cell_width, cell_height) = grid_list.cell_size;
+                    let mouse_row = (event.pos.y / cell_height) as usize;
+                    let mouse_col = (event.pos.x / cell_width) as usize;
+                    let shape_row = mouse_row.saturating_sub(self.offset_row);
+                    let shape_col = mouse_col.saturating_sub(self.offset_col);
+                    block.start = (shape_row, shape_col);
+                }
+            }
+        }
     }
 
     fn input(
@@ -53,5 +95,6 @@ impl ToolControl for SelectTool {
         _grid_list: &mut GridList,
     ) {
         ctx.submit_command(SELECTION_END_COMMAND.with(event.pos));
+        self.is_selecting = false;
     }
 }


### PR DESCRIPTION
Now we can select something on the screen and move it around.

![2023-03-23 18 20 16](https://user-images.githubusercontent.com/613943/227400341-b8e29565-bfc5-4e00-87e8-72c534b1785f.gif)

Under the hood, it works like this:

1. If the user starts dragging a selection, we will do the following:
    a. create a new Block shape from the current selection, and put it in Preview mode
    b. discard the selected content
2. When the user drags the mouse, we will update the position of the Block shape
3. When the user finished dragging, we commit the Block shape to the Grid list