### PR TITLE
feat: Implement window-level data handling

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,4 +1,5 @@
-use druid::Data;
+use druid::{Data, WindowId};
+use std::collections::HashMap;
 
 use crate::tools::DrawingTools;
 
@@ -10,8 +11,23 @@ pub mod shape_list;
 
 mod overlap;
 
-#[derive(Clone, PartialEq, Data)]
-pub struct ApplicationState {
+#[derive(Clone, PartialEq, Data, Debug)]
+pub struct WindowData {
     pub mode: DrawingTools,
     pub current_file: Option<String>,
+}
+
+impl WindowData {
+    pub fn new() -> Self {
+        Self {
+            mode: DrawingTools::Select,
+            current_file: None,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Data, Debug)]
+pub struct ApplicationState {
+    #[data(eq)]
+    pub windows: HashMap<WindowId, WindowData>,
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -18,7 +18,7 @@ pub mod rect;
 pub mod select;
 pub mod text;
 
-#[derive(Clone, Copy, PartialEq, Data)]
+#[derive(Clone, Copy, PartialEq, Data, Debug)]
 pub enum DrawingTools {
     Select = 0,
     Line = 1,


### PR DESCRIPTION
Previously, when you have one window, you can edit and save file normally. When you open a new window and draw some new thing, then hit save, it saves the new content into the file from the original window! You may think it's because in life, you can never have more than one nice thing, that you should never ever be multitasking, at any point, you should be focused, comitted to only one thing at a time is a key for a success life, as many successful people said.

Turned out, it's a bug! My bad, I didn't know the fact that ApplicationState is tracked at application's root level, not on window level. So all windows would share the same ApplicationState.

To fix this issue, I need to restructure the ApplicationState, split it up to a HashMap is the first thing that come to my mind, and it looks good enough. So here we go.